### PR TITLE
Add hint to `CheckTargetType` call: "(did you supply too few arguments to [function] ?)"

### DIFF
--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -556,15 +556,10 @@ instance PrettyTCM TypeError where
           [ [return d1, notCmp cmp, return d2]
           , case a of
                 AsTermsOf t -> pwords "of type" ++ [prettyTCM t]
-                AsSizes     -> pwords "of type" ++ [prettyTCM =<< sizeType] 
+                AsSizes     -> pwords "of type" ++ [prettyTCM =<< sizeType]
                 AsTypes     -> []
           , [return d]
           ]
-      -- where
-      --   argSuggestion = case s of
-      --             I.Pi a b -> pwords "(did you supply too few arguments to a function?)"
-      --             _ -> []
-        
 
     UnequalLevel cmp s t -> fsep $
       [prettyTCM s, notCmp cmp, prettyTCM t]

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -557,7 +557,9 @@ instance PrettyTCM TypeError where
           , case a of
                 AsTermsOf t -> pwords "of type" ++ [prettyTCM t]
                 AsSizes     -> pwords "of type" ++ [prettyTCM =<< sizeType]
-                AsTypes     -> []
+                AsTypes     -> {-[]-} case s of
+                  I.Pi a b -> ["(did you supply too few arguments to a function?)"]
+                  _ -> []
           , [return d]
           ]
 

--- a/src/full/Agda/TypeChecking/Errors.hs
+++ b/src/full/Agda/TypeChecking/Errors.hs
@@ -556,12 +556,15 @@ instance PrettyTCM TypeError where
           [ [return d1, notCmp cmp, return d2]
           , case a of
                 AsTermsOf t -> pwords "of type" ++ [prettyTCM t]
-                AsSizes     -> pwords "of type" ++ [prettyTCM =<< sizeType]
-                AsTypes     -> {-[]-} case s of
-                  I.Pi a b -> ["(did you supply too few arguments to a function?)"]
-                  _ -> []
+                AsSizes     -> pwords "of type" ++ [prettyTCM =<< sizeType] 
+                AsTypes     -> []
           , [return d]
           ]
+      -- where
+      --   argSuggestion = case s of
+      --             I.Pi a b -> pwords "(did you supply too few arguments to a function?)"
+      --             _ -> []
+        
 
     UnequalLevel cmp s t -> fsep $
       [prettyTCM s, notCmp cmp, prettyTCM t]

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -3726,7 +3726,7 @@ instance HasRange Call where
     getRange (InferDef f)                        = getRange f
     getRange (CheckArguments fun _ _ _)          = getRange fun
     getRange (CheckMetaSolution r _ _ _)         = r
-    getRange (CheckTargetType r _ _ _)             = r
+    getRange (CheckTargetType r _ _ _)           = r
     getRange (CheckDataDef i _ _ _)              = getRange i
     getRange (CheckRecDef i _ _ _)               = getRange i
     getRange (CheckConstructor _ _ _ c)          = getRange c

--- a/src/full/Agda/TypeChecking/Monad/Base.hs
+++ b/src/full/Agda/TypeChecking/Monad/Base.hs
@@ -3638,7 +3638,7 @@ data Call
   | InferDef QName
   | CheckArguments A.Expr [NamedArg A.Expr] Type (Maybe Type)
   | CheckMetaSolution Range MetaId Type Term
-  | CheckTargetType Range Type Type
+  | CheckTargetType Range Type Type A.Expr
   | CheckDataDef Range QName [A.LamBinding] [A.Constructor]
   | CheckRecDef Range QName [A.LamBinding] [A.Constructor]
   | CheckConstructor QName Telescope Sort A.Constructor
@@ -3726,7 +3726,7 @@ instance HasRange Call where
     getRange (InferDef f)                        = getRange f
     getRange (CheckArguments fun _ _ _)          = getRange fun
     getRange (CheckMetaSolution r _ _ _)         = r
-    getRange (CheckTargetType r _ _)             = r
+    getRange (CheckTargetType r _ _ _)             = r
     getRange (CheckDataDef i _ _ _)              = getRange i
     getRange (CheckRecDef i _ _ _)               = getRange i
     getRange (CheckConstructor _ _ _ c)          = getRange c

--- a/src/full/Agda/TypeChecking/Pretty/Call.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Call.hs
@@ -116,16 +116,15 @@ instance PrettyTCM Call where
       pwords "of metavariable" ++ [prettyTCM m] ++
       pwords "has the expected type" ++ [prettyTCM a]
 
-    CheckTargetType r infTy expTy sFun -> sep
+    CheckTargetType r infTy expTy sFun -> sep $
       [ "when checking that the inferred type of an application"
       , nest 2 $ prettyTCM infTy
       , "matches the expected type"
-      , nest 2 $ prettyTCM expTy
-      , sep tmp ]
-      where
-        tmp = case unEl infTy of
-          Agda.Syntax.Internal.Pi a b -> pwords "(did you supply too few arguments to " ++ [prettyTCM sFun] ++ pwords "?)"
-          _ -> []
+      , nest 2 $ prettyTCM expTy 
+      ] ++
+      [ sep (pwords "(did you supply too few arguments to " ++ [prettyTCM sFun] ++ pwords "?)") 
+      | Agda.Syntax.Internal.Pi _ _ <- [unEl infTy]
+      ]
 
     CheckRecDef _ x ps cs ->
       fsep $ pwords "when checking the definition of" ++ [prettyTCM x]

--- a/src/full/Agda/TypeChecking/Pretty/Call.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Call.hs
@@ -116,11 +116,16 @@ instance PrettyTCM Call where
       pwords "of metavariable" ++ [prettyTCM m] ++
       pwords "has the expected type" ++ [prettyTCM a]
 
-    CheckTargetType r infTy expTy -> sep
+    CheckTargetType r infTy expTy sFun -> sep
       [ "when checking that the inferred type of an application"
       , nest 2 $ prettyTCM infTy
       , "matches the expected type"
-      , nest 2 $ prettyTCM expTy ]
+      , nest 2 $ prettyTCM expTy
+      , sep tmp ]
+      where
+        tmp = case unEl infTy of
+          Agda.Syntax.Internal.Pi a b -> pwords "(did you supply too few arguments to " ++ [prettyTCM sFun] ++ pwords "?)"
+          _ -> []
 
     CheckRecDef _ x ps cs ->
       fsep $ pwords "when checking the definition of" ++ [prettyTCM x]

--- a/src/full/Agda/TypeChecking/Rules/Application.hs
+++ b/src/full/Agda/TypeChecking/Rules/Application.hs
@@ -760,7 +760,7 @@ checkArgumentsE'
                   chk <-
                     traceCall
                       (CheckTargetType
-                         (fuseRange sFun sArgs) tgt1 sResultType) $
+                         (fuseRange sFun sArgs) tgt1 sResultType sFun) $
                       CheckedTarget <$>
                         ifNoConstraints_ (compareType sComp tgt1 sResultType)
                           (return Nothing) (return . Just)


### PR DESCRIPTION
This adds a new hint that suggests if too few arguments were supplied to a function. This targets novice Agda programmers who may be unfamiliar with Agda types.

## Example

```agda
open import Agda.Builtin.Nat

addThree : Nat → Nat → Nat → Nat
addThree a b c = a + b + c 

num : Nat
num = addThree 1 2
```
```
Nat → Nat !=< Nat
when checking that the inferred type of an application
  Nat → Nat
matches the expected type
  Nat
(did you supply too few arguments to addThree ?)
```

---
This PR was a part of my [Master's thesis](https://repository.tudelft.nl/record/uuid:52513287-7149-41f1-a8e8-8e38696cb283).