### PR TITLE
Add hint to `NotInScopeW` for potentially missing space between names

### DIFF
--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -710,8 +710,9 @@ didYouMeanInfix inscope canon x
   -- dropModule x = fromMaybe x $ List.stripPrefix "module " x
   -- maxDist n    = div n 3
   -- close a b    = editDistance a b <= maxDist (length a)
-  tmp = filter (\y -> (strip . C.unqualify $ y) `List.isInfixOf` (strip $ canon x)) inscope
-  ys = map prettyShow $ tmp
+  infixes = filter (\y -> (strip . C.unqualify $ y) `List.isInfixOf` (strip $ canon x)) inscope
+  ys = List.nub $ map (\y -> prettyShow . C.unqualify $ y) infixes
+  -- ys = map prettyShow $ infixes
 
 prettyTCWarnings :: Set TCWarning -> TCM String
 prettyTCWarnings = List.intercalate "\n" <.> map P.render <.> prettyTCWarnings'

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -697,7 +697,7 @@ didYouMeanInfix
   -> a             -- ^ A name which is not in scope.
   -> Maybe (m Doc) -- ^ "did you mean" hint.
 didYouMeanInfix inscope canon x
-  | null ys   = Just "NEW: list of potential stuff was empty"
+  | null ys   = Nothing --Just "NEW: list of potential stuff was empty"
   | otherwise = Just $ sep
       [ "NEW: did you forget whitespace in "
       , nest 2 (vcat $ punctuate " or" $
@@ -706,7 +706,7 @@ didYouMeanInfix inscope canon x
       ]
   where
   strip :: Pretty b => b -> String
-  strip        = map toLower . filter (/= '_') . prettyShow
+  strip        = filter (/= '_') . prettyShow
   -- dropModule x = fromMaybe x $ List.stripPrefix "module " x
   -- maxDist n    = div n 3
   -- close a b    = editDistance a b <= maxDist (length a)
@@ -714,7 +714,7 @@ didYouMeanInfix inscope canon x
   wordBreakHelp wordSet modWordSet curWords [] = [curWords]
   wordBreakHelp wordSet [] curWords word = []
   wordBreakHelp wordSet (y:ys) curWords word
-    | y `List.isPrefixOf` word = (wordBreakHelp wordSet wordSet (curWords ++ [y]) (drop (length y) word)) ++ (wordBreakHelp wordSet ys curWords word)
+    | (y `List.isPrefixOf` word) && (not $ null y) = (wordBreakHelp wordSet wordSet (curWords ++ [y]) (drop (length y) word)) ++ (wordBreakHelp wordSet ys curWords word) --TODO: ask jesper
     | otherwise = wordBreakHelp wordSet ys curWords word
 
   wordBreak :: [String] -> String -> [[String]]
@@ -723,8 +723,9 @@ didYouMeanInfix inscope canon x
   infixes = filter (\y -> (strip . C.unqualify $ y) `List.isInfixOf` (strip $ canon x)) inscope
   tmp = List.nub $ map (\y -> prettyShow . strip . C.unqualify $ y) infixes
 
-  ys = map unwords . wordBreak tmp . strip $ canon x
-  -- ys = map prettyShow $ infixes
+  -- need to filter out cases where the entire stripped name is in scope, as spaces cannot help (e.g. see test/Fail/AnonymousImport)
+  ys = map unwords . filter ((> 1) . length) . wordBreak tmp . strip $ canon x
+  --ys = map prettyShow $ infixes
 
 prettyTCWarnings :: Set TCWarning -> TCM String
 prettyTCWarnings = List.intercalate "\n" <.> map P.render <.> prettyTCWarnings'

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -501,7 +501,6 @@ prettyWarning = \case
       [ fsep $ pwords "Not in scope:"
       , do
         inscope <- Set.toList . concreteNamesInScope <$> getScope
-        reportSDoc "maria" 10 $ "everything in scope (hopefully): " <+> prettyTCM inscope
         prettyNotInScopeNames True (suggestion inscope) $ singleton x
       ]
       where
@@ -699,7 +698,7 @@ didYouMeanInfix
 didYouMeanInfix inscope canon x
   | null ys   = Nothing --Just "NEW: list of potential stuff was empty"
   | otherwise = Just $ sep
-      [ "NEW: did you forget whitespace in "
+      [ "did you forget whitespace in "
       , nest 2 (vcat $ punctuate " or" $
                  map (\ y -> text $ "'" ++ y ++ "'") ys)
         <> "?"

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -507,9 +507,8 @@ prettyWarning = \case
       suggestion inscope x = nest 2 $ par $ concat
         [ [ "did you forget space around the ':'?"  | ':' `elem` s ]
         , [ "did you forget space around the '->'?" | "->" `List.isInfixOf` s ]
-        -- , [ "did you forget space around the ','?"  | ',' `elem` s ]
         , maybeToList $ didYouMean inscope C.unqualify x
-        , maybeToList $ didYouMeanInfix inscope C.unqualify x
+        , maybeToList $ didYouForgetSpace inscope C.unqualify x
         ]
         where
         par []  = empty
@@ -687,16 +686,16 @@ didYouMean inscope canon x
   close a b    = editDistance a b <= maxDist (length a)
   ys           = map prettyShow $ filter (close (strip $ canon x) . strip . C.unqualify) inscope
 
-{-# SPECIALIZE didYouMeanInfix :: (Pretty a, Pretty b) => [C.QName] -> (a -> b) -> a -> Maybe (TCM Doc) #-}
+{-# SPECIALIZE didYouForgetSpace :: (Pretty a, Pretty b) => [C.QName] -> (a -> b) -> a -> Maybe (TCM Doc) #-}
 -- | Suggest a correction if the name can be completely broken down into names in scope.
-didYouMeanInfix
+didYouForgetSpace
   :: (MonadPretty m, Pretty a, Pretty b)
   => [C.QName]     -- ^ Names in scope.
   -> (a -> b)      -- ^ Canonization function for similarity search.
   -> a             -- ^ A name which is not in scope.
-  -> Maybe (m Doc) -- ^ "did you mean" hint.
-didYouMeanInfix inscope canon x
-  | null ys   = Nothing --Just "NEW: list of potential stuff was empty"
+  -> Maybe (m Doc) -- ^ "did you forget whitespace in ..." hint.
+didYouForgetSpace inscope canon x
+  | null ys   = Nothing
   | otherwise = Just $ sep
       [ "did you forget whitespace in "
       , nest 2 (vcat $ punctuate " or" $
@@ -706,25 +705,22 @@ didYouMeanInfix inscope canon x
   where
   strip :: Pretty b => b -> String
   strip        = filter (/= '_') . prettyShow
-  -- dropModule x = fromMaybe x $ List.stripPrefix "module " x
-  -- maxDist n    = div n 3
-  -- close a b    = editDistance a b <= maxDist (length a)
+
   wordBreakHelp :: [String] -> [String] -> [String] -> String -> [[String]]
   wordBreakHelp wordSet modWordSet curWords [] = [curWords]
   wordBreakHelp wordSet [] curWords word = []
   wordBreakHelp wordSet (y:ys) curWords word
-    | (y `List.isPrefixOf` word) && (not $ null y) = (wordBreakHelp wordSet wordSet (curWords ++ [y]) (drop (length y) word)) ++ (wordBreakHelp wordSet ys curWords word) --TODO: ask jesper
+    | (y `List.isPrefixOf` word) && (not $ null y) =
+      (wordBreakHelp wordSet wordSet (curWords ++ [y]) (drop (length y) word)) ++ (wordBreakHelp wordSet ys curWords word)
     | otherwise = wordBreakHelp wordSet ys curWords word
 
   wordBreak :: [String] -> String -> [[String]]
   wordBreak wordSet word = wordBreakHelp wordSet wordSet [] word
 
-  infixes = filter (\y -> (strip . C.unqualify $ y) `List.isInfixOf` (strip $ canon x)) inscope
-  tmp = List.nub $ map (\y -> prettyShow . strip . C.unqualify $ y) infixes
+  infixes = List.nub $ filter (`List.isInfixOf` strip (canon x)) $ map (strip . C.unqualify) inscope
 
-  -- need to filter out cases where the entire stripped name is in scope, as spaces cannot help (e.g. see test/Fail/AnonymousImport)
-  ys = map unwords . filter ((> 1) . length) . wordBreak tmp . strip $ canon x
-  --ys = map prettyShow $ infixes
+  -- need to filter out cases where the entire strkipped name is in scope, as spaces cannot help (e.g. see test/Fail/AnonymousImport)
+  ys = map unwords . filter ((> 1) . length) . wordBreak infixes . strip $ canon x
 
 prettyTCWarnings :: Set TCWarning -> TCM String
 prettyTCWarnings = List.intercalate "\n" <.> map P.render <.> prettyTCWarnings'

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -706,16 +706,22 @@ didYouForgetSpace inscope canon x
   strip :: Pretty b => b -> String
   strip        = filter (/= '_') . prettyShow
 
-  wordBreakHelp :: [String] -> [String] -> [String] -> String -> [[String]]
-  wordBreakHelp wordSet modWordSet curWords [] = [curWords]
-  wordBreakHelp wordSet [] curWords word = []
-  wordBreakHelp wordSet (y:ys) curWords word
-    | (y `List.isPrefixOf` word) && (not $ null y) =
-      (wordBreakHelp wordSet wordSet (curWords ++ [y]) (drop (length y) word)) ++ (wordBreakHelp wordSet ys curWords word)
-    | otherwise = wordBreakHelp wordSet ys curWords word
+  dropPrefix :: Eq a => [a] -> [a] -> Maybe [a]
+  dropPrefix (x:xs) (y:ys)
+    | x == y = dropPrefix xs ys
+    | otherwise = Nothing
+  dropPrefix [] ys = Just ys
+  dropPrefix _ [] = Nothing
 
   wordBreak :: [String] -> String -> [[String]]
-  wordBreak wordSet word = wordBreakHelp wordSet wordSet [] word
+  wordBreak wordSet word = go wordSet wordSet [] word where
+    go wordSet modWordSet curWords [] = [curWords]
+    go wordSet [] curWords word = []
+    go wordSet ("":ys) curWords word = go wordSet ys curWords word
+    go wordSet (y:ys) curWords word = 
+      (do rest <- maybeToList (dropPrefix y word)
+          go wordSet wordSet (curWords ++ [y]) rest)
+      ++ go wordSet ys curWords word
 
   infixes = List.nub $ filter (`List.isInfixOf` strip (canon x)) $ map (strip . C.unqualify) inscope
 

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -508,8 +508,9 @@ prettyWarning = \case
       suggestion inscope x = nest 2 $ par $ concat
         [ [ "did you forget space around the ':'?"  | ':' `elem` s ]
         , [ "did you forget space around the '->'?" | "->" `List.isInfixOf` s ]
-        , [ "did you forget space around the ','?"  | ',' `elem` s ]
+        -- , [ "did you forget space around the ','?"  | ',' `elem` s ]
         , maybeToList $ didYouMean inscope C.unqualify x
+        , maybeToList $ didYouMeanInfix inscope C.unqualify x
         ]
         where
         par []  = empty
@@ -687,6 +688,30 @@ didYouMean inscope canon x
   close a b    = editDistance a b <= maxDist (length a)
   ys           = map prettyShow $ filter (close (strip $ canon x) . strip . C.unqualify) inscope
 
+{-# SPECIALIZE didYouMeanInfix :: (Pretty a, Pretty b) => [C.QName] -> (a -> b) -> a -> Maybe (TCM Doc) #-}
+-- | Suggest some corrections to a misspelled name.
+didYouMeanInfix
+  :: (MonadPretty m, Pretty a, Pretty b)
+  => [C.QName]     -- ^ Names in scope.
+  -> (a -> b)      -- ^ Canonization function for similarity search.
+  -> a             -- ^ A name which is not in scope.
+  -> Maybe (m Doc) -- ^ "did you mean" hint.
+didYouMeanInfix inscope canon x
+  | null ys   = Just "NEW: list of potential stuff was empty"
+  | otherwise = Just $ sep
+      [ "NEW: did you forget space around the "
+      , nest 2 (vcat $ punctuate " or" $
+                 map (\ y -> text $ "'" ++ y ++ "'") ys)
+        <> "?"
+      ]
+  where
+  strip :: Pretty b => b -> String
+  strip        = map toLower . filter (/= '_') . prettyShow
+  -- dropModule x = fromMaybe x $ List.stripPrefix "module " x
+  -- maxDist n    = div n 3
+  -- close a b    = editDistance a b <= maxDist (length a)
+  tmp = filter (\y -> (strip . C.unqualify $ y) `List.isInfixOf` (strip $ canon x)) inscope
+  ys = map prettyShow $ tmp
 
 prettyTCWarnings :: Set TCWarning -> TCM String
 prettyTCWarnings = List.intercalate "\n" <.> map P.render <.> prettyTCWarnings'

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -501,6 +501,7 @@ prettyWarning = \case
       [ fsep $ pwords "Not in scope:"
       , do
         inscope <- Set.toList . concreteNamesInScope <$> getScope
+        reportSDoc "maria" 10 $ "everything in scope (hopefully): " <+> prettyTCM inscope
         prettyNotInScopeNames True (suggestion inscope) $ singleton x
       ]
       where

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -689,7 +689,7 @@ didYouMean inscope canon x
   ys           = map prettyShow $ filter (close (strip $ canon x) . strip . C.unqualify) inscope
 
 {-# SPECIALIZE didYouMeanInfix :: (Pretty a, Pretty b) => [C.QName] -> (a -> b) -> a -> Maybe (TCM Doc) #-}
--- | Suggest some corrections to a misspelled name.
+-- | Suggest a correction if the name can be completely broken down into names in scope.
 didYouMeanInfix
   :: (MonadPretty m, Pretty a, Pretty b)
   => [C.QName]     -- ^ Names in scope.
@@ -699,7 +699,7 @@ didYouMeanInfix
 didYouMeanInfix inscope canon x
   | null ys   = Just "NEW: list of potential stuff was empty"
   | otherwise = Just $ sep
-      [ "NEW: did you forget space around the "
+      [ "NEW: did you forget whitespace in "
       , nest 2 (vcat $ punctuate " or" $
                  map (\ y -> text $ "'" ++ y ++ "'") ys)
         <> "?"
@@ -710,8 +710,20 @@ didYouMeanInfix inscope canon x
   -- dropModule x = fromMaybe x $ List.stripPrefix "module " x
   -- maxDist n    = div n 3
   -- close a b    = editDistance a b <= maxDist (length a)
+  wordBreakHelp :: [String] -> [String] -> [String] -> String -> [[String]]
+  wordBreakHelp wordSet modWordSet curWords [] = [curWords]
+  wordBreakHelp wordSet [] curWords word = []
+  wordBreakHelp wordSet (y:ys) curWords word
+    | y `List.isPrefixOf` word = (wordBreakHelp wordSet wordSet (curWords ++ [y]) (drop (length y) word)) ++ (wordBreakHelp wordSet ys curWords word)
+    | otherwise = wordBreakHelp wordSet ys curWords word
+
+  wordBreak :: [String] -> String -> [[String]]
+  wordBreak wordSet word = wordBreakHelp wordSet wordSet [] word
+
   infixes = filter (\y -> (strip . C.unqualify $ y) `List.isInfixOf` (strip $ canon x)) inscope
-  ys = List.nub $ map (\y -> prettyShow . C.unqualify $ y) infixes
+  tmp = List.nub $ map (\y -> prettyShow . strip . C.unqualify $ y) infixes
+
+  ys = map unwords . wordBreak tmp . strip $ canon x
   -- ys = map prettyShow $ infixes
 
 prettyTCWarnings :: Set TCWarning -> TCM String

--- a/src/full/Agda/TypeChecking/Pretty/Warning.hs
+++ b/src/full/Agda/TypeChecking/Pretty/Warning.hs
@@ -507,6 +507,7 @@ prettyWarning = \case
       suggestion inscope x = nest 2 $ par $ concat
         [ [ "did you forget space around the ':'?"  | ':' `elem` s ]
         , [ "did you forget space around the '->'?" | "->" `List.isInfixOf` s ]
+        , [ "did you forget space around the ','?"  | ',' `elem` s ]
         , maybeToList $ didYouMean inscope C.unqualify x
         ]
         where


### PR DESCRIPTION
Adds a new hint to the `NotInScopeW` error message if the scope error can be resolved by inserting spaces. This targets a common mistake novice programmers make when writing Agda.

## Example

```agda
postulate
    A B : Set

data _×_ (A B : Set) : Set where
  _,_ : A → B → A × B

swap : A × B → B × A
swap (x , y) = (y, x)
```
```
Not in scope:
  y, at example.agda:8.17-19
    (did you forget whitespace in  'y ,'?)
when scope checking y,
```
---
This PR was a part of my [Master's thesis](https://repository.tudelft.nl/record/uuid:52513287-7149-41f1-a8e8-8e38696cb283)

